### PR TITLE
fix: export default bug

### DIFF
--- a/ast-parser/src/Parser.ts
+++ b/ast-parser/src/Parser.ts
@@ -167,7 +167,7 @@ export class Parser {
         exportDeclaration = {
           type: NodeType.ExportDefaultDeclaration,
           declaration: local,
-          start: local.start,
+          start: start,
           end: local.end,
         };
       }


### PR DESCRIPTION
原来生成的语法树：
<img width="616" alt="image" src="https://github.com/user-attachments/assets/2fa59fe2-603c-4dea-9f9f-fa64a34c16c9">
arcon生成的语法树：
<img width="1721" alt="image" src="https://github.com/user-attachments/assets/88de7cda-2ae0-491d-a05b-6f9e3cadae28">
